### PR TITLE
Upgrade to Auth.js v5

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ PUBLIC_STRIPE_KEY=pk_...
 SECRET_STRIPE_KEY=sk_...
 DOMAIN=http://localhost:5173
 DATABASE_URL="postgresql://postgres:postgres@localhost:5432/auth_stripe_sveltekit_dev?schema=public"
+AUTH_GITHUB_ID=
+AUTH_GITHUB_SECRET=
 ```
 
 Configure authentication and billing options in `src/hooks.server.js`:
@@ -97,7 +99,7 @@ Configure authentication and billing options in `src/hooks.server.js`:
 import { SvelteKitAuth } from '@airbadge/sveltekit'
 
 // use any OAuth provider (or multiple)
-import GitHub from '@auth/core/providers/github'
+import GitHub from '@auth/sveltekit/providers/github'
 
 // import prisma client for Auth.js's database adapter
 import { PrismaClient } from '@prisma/client'
@@ -107,17 +109,12 @@ const db = new PrismaClient()
 
 // add Auth.js + Stripe handler
 // API is similar to Auth.js
-export const handle = SvelteKitAuth({
+export const { handle } = SvelteKitAuth({
   // configure database adapter
   adapter: PrismaAdapter(db),
 
   // configure OAuth providers
-  providers: [
-    GitHub({
-      clientId: env.GITHUB_ID,
-      clientSecret: env.GITHUB_SECRET
-    })
-  ]
+  providers: [ GitHub ]
 })
 ```
 

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -12,8 +12,8 @@
   },
   "devDependencies": {
     "@airbadge/sveltekit": "link:../../packages/sveltekit",
-    "@auth/core": "^0.25.0",
-    "@auth/prisma-adapter": "^1.1.0",
+    "@auth/prisma-adapter": "^2.1.0",
+    "@auth/sveltekit": "^1.1.0",
     "@iconify/svelte": "^3.1.6",
     "@prisma/client": "^5.9.0",
     "@sveltejs/adapter-auto": "^3.0.0",

--- a/apps/app/src/hooks.server.js
+++ b/apps/app/src/hooks.server.js
@@ -3,16 +3,13 @@ import * as Sentry from '@sentry/sveltekit'
 import { SvelteKitAuth } from '@airbadge/sveltekit'
 
 // use GitHub OAuth provider
-import GitHub from '@auth/core/providers/github'
+import GitHub from '@auth/sveltekit/providers/github'
 
 // use Prisma database adapter
 import { PrismaAdapter } from '@auth/prisma-adapter'
 
 // import Prisma client for database adapter
 import { PrismaClient } from '@prisma/client'
-
-// import env vars for OAuth client
-import { env } from '$env/dynamic/private'
 
 Sentry.init({
   dsn: 'https://f0853627ab1eb2822f1a2aa3b572cdd7@o4506863366832128.ingest.us.sentry.io/4506953208954880',
@@ -25,16 +22,16 @@ const db = new PrismaClient()
 
 // add Auth.js + Stripe handler
 // API is similar to Auth.js
+const { handle: handleAuth } = SvelteKitAuth({
+  adapter: PrismaAdapter(db),
+  providers: [
+    GitHub
+  ],
+})
+
 export const handle = sequence(
   Sentry.sentryHandle(),
-  SvelteKitAuth({
-    adapter: PrismaAdapter(db),
-    providers: [
-      GitHub({
-        clientId: env.GITHUB_ID,
-        clientSecret: env.GITHUB_SECRET
-      })
-    ],
-  })
+  handleAuth,
 )
+
 export const handleError = Sentry.handleErrorWithSentry()

--- a/apps/docs/src/routes/configuration/+page.md
+++ b/apps/docs/src/routes/configuration/+page.md
@@ -28,19 +28,13 @@ AirBadge supports all [Auth.js authentication providers](https://authjs.dev/refe
 
 ### Example
 
-```js {7-11}
+```js {6-6}
 // in src/hooks.server.js
 import { SvelteKitAuth } from '@airbadge/sveltekit'
-import GitHub from '@auth/core/providers/github'
-import { env } from '$env/dynamic/private'
+import GitHub from '@auth/sveltekit/providers/github'
 
-export const handle = SvelteKitAuth({
-  providers: [
-    GitHub({
-      clientId: env.GITHUB_ID,
-      clientSecret: env.GITHUB_SECRET
-    })
-  ]
+export const { handle } = SvelteKitAuth({
+  providers: [ GitHub ]
 })
 ```
 

--- a/apps/docs/src/routes/getting-started/+page.md
+++ b/apps/docs/src/routes/getting-started/+page.md
@@ -7,7 +7,7 @@ This guide uses [Prisma](https://prisma.io) for database access and [GitHub](htt
 For Auth & Payment:
 
 ```sh
-pnpm install -D @auth/core @airbadge/sveltekit
+pnpm install -D @airbadge/sveltekit
 ```
 
 For Prisma:
@@ -34,8 +34,8 @@ DATABASE_URL="postgresql://postgres:postgres@localhost:5432/mydb?schema=public"
 
 # Client Id and Client Secret of GitHub OAuth app
 # In GitHub: Settings -> Developer Settings -> OAuth Apps
-GITHUB_ID=
-GITHUB_SECRET=
+AUTH_GITHUB_ID=
+AUTH_GITHUB_SECRET=
 ```
 
 ## Setup database
@@ -170,7 +170,7 @@ Configure authentication and billing options in `src/hooks.server.js`:
 import { SvelteKitAuth } from '@airbadge/sveltekit'
 
 // use GitHub OAuth provider
-import GitHub from '@auth/core/providers/github'
+import GitHub from '@auth/sveltekit/providers/github'
 
 // use Prisma database adapter
 import { PrismaAdapter } from '@auth/prisma-adapter'
@@ -178,22 +178,14 @@ import { PrismaAdapter } from '@auth/prisma-adapter'
 // import Prisma client for database adapter
 import { PrismaClient } from '@prisma/client'
 
-// import env vars for OAuth client
-import { env } from '$env/dynamic/private'
-
 // init database client
 const db = new PrismaClient()
 
 // add Auth.js + Stripe handler
 // API is similar to Auth.js
-export const handle = SvelteKitAuth({
+export const { handle } = SvelteKitAuth({
   adapter: PrismaAdapter(db),
-  providers: [
-    GitHub({
-      clientId: env.GITHUB_ID,
-      clientSecret: env.GITHUB_SECRET
-    })
-  ]
+  providers: [ GitHub ]
 })
 ```
 

--- a/apps/web/src/routes/Demo.svelte
+++ b/apps/web/src/routes/Demo.svelte
@@ -3,8 +3,9 @@
   import { onMount } from 'svelte'
 
   const code = `import { SvelteKitAuth } from '@airbadge/sveltekit'
+import { PrismaAdapter } from '@auth/prisma-adapter'
 
-export const handle = SvelteKitAuth({
+export const { handle } = SvelteKitAuth({
   adapter: PrismaAdapter(...),
 
   providers: [

--- a/packages/sveltekit/package.json
+++ b/packages/sveltekit/package.json
@@ -41,7 +41,7 @@
     "svelte": "^4.0.0"
   },
   "devDependencies": {
-    "@auth/prisma-adapter": "^1.1.0",
+    "@auth/prisma-adapter": "^2.1.0",
     "@faker-js/faker": "^8.4.0",
     "@playwright/test": "^1.28.1",
     "@prisma/client": "^5.9.0",
@@ -69,8 +69,7 @@
   "types": "./dist/index.d.ts",
   "type": "module",
   "dependencies": {
-    "@auth/core": "^0.25.0",
-    "@auth/sveltekit": "^0.10.0",
+    "@auth/sveltekit": "^1.1.0",
     "stripe": "^14.14.0",
     "@sveltejs/kit": "^2.0.6"
   },

--- a/packages/sveltekit/src/hooks.server.js
+++ b/packages/sveltekit/src/hooks.server.js
@@ -1,12 +1,12 @@
 import { SvelteKitAuth } from '$lib'
 import { PrismaClient } from '@prisma/client'
 import { PrismaAdapter } from '@auth/prisma-adapter'
-import Credentials from '@auth/core/providers/credentials'
+import Credentials from '@auth/sveltekit/providers/credentials'
 import { env } from '$env/dynamic/private'
 
 const db = new PrismaClient()
 
-export const handle = SvelteKitAuth({
+export const { handle } = SvelteKitAuth({
   trustHost: true,
   adapter: new PrismaAdapter(db),
   session: {

--- a/packages/sveltekit/src/lib/index.js
+++ b/packages/sveltekit/src/lib/index.js
@@ -24,8 +24,9 @@ export function SvelteKitAuth(options = {}) {
     billing,
     options
   }
+  const { handle, ...rest } = authHandler(options)
 
-  return sequence(authHandler(options), paymentHandler(state))
+  return { ...rest, handle: sequence(handle, paymentHandler(state)) }
 }
 
 function authHandler(options) {

--- a/packages/sveltekit/src/lib/index.test.js
+++ b/packages/sveltekit/src/lib/index.test.js
@@ -28,11 +28,11 @@ describe('SvelteKitAuth', () => {
     }
 
     test('handles /auth', async () => {
-      const handler = SvelteKitAuth(config)
+      const { handle } = SvelteKitAuth(config)
 
       const url = new URL('http://localhost/auth/providers')
-      //
-      const response = await handler({
+
+      const response = await handle({
         event: {
           url,
           locals: {},
@@ -48,9 +48,9 @@ describe('SvelteKitAuth', () => {
     })
 
     test('handles /billing', async () => {
-      const handler = SvelteKitAuth(config)
+      const { handle } = SvelteKitAuth(config)
 
-      const response = await handler({
+      const response = await handle({
         event: {
           url: new URL('http://localhost/billing/portal'),
           locals: {
@@ -67,7 +67,7 @@ describe('SvelteKitAuth', () => {
 
     test('ignores everything else', async () => {
       const resolve = vi.fn()
-      const handler = SvelteKitAuth(config)
+      const { handle } = SvelteKitAuth(config)
       const event = {
         url: new URL('http://localhost/unknown'),
         locals: {
@@ -78,7 +78,7 @@ describe('SvelteKitAuth', () => {
         }
       }
 
-      const response = await handler({ resolve, event })
+      const response = await handle({ resolve, event })
 
       expect(response).toBeUndefined()
       expect(resolve).toHaveBeenCalled()

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,12 +36,12 @@ importers:
       '@airbadge/sveltekit':
         specifier: link:../../packages/sveltekit
         version: link:../../packages/sveltekit
-      '@auth/core':
-        specifier: ^0.25.0
-        version: 0.25.0
       '@auth/prisma-adapter':
+        specifier: ^2.1.0
+        version: 2.1.0(@prisma/client@5.9.0)
+      '@auth/sveltekit':
         specifier: ^1.1.0
-        version: 1.1.0(@prisma/client@5.9.0)
+        version: 1.1.0(@sveltejs/kit@2.0.6)(svelte@4.2.8)
       '@iconify/svelte':
         specifier: ^3.1.6
         version: 3.1.6(svelte@4.2.8)
@@ -285,12 +285,9 @@ importers:
 
   packages/sveltekit:
     dependencies:
-      '@auth/core':
-        specifier: ^0.25.0
-        version: 0.25.0
       '@auth/sveltekit':
-        specifier: ^0.10.0
-        version: 0.10.0(@sveltejs/kit@2.0.6)(svelte@4.2.8)
+        specifier: ^1.1.0
+        version: 1.1.0(@sveltejs/kit@2.0.6)(svelte@4.2.8)
       '@sveltejs/kit':
         specifier: ^2.0.6
         version: 2.0.6(@sveltejs/vite-plugin-svelte@3.0.1)(svelte@4.2.8)(vite@5.0.11)
@@ -299,8 +296,8 @@ importers:
         version: 14.14.0
     devDependencies:
       '@auth/prisma-adapter':
-        specifier: ^1.1.0
-        version: 1.1.0(@prisma/client@5.9.0)
+        specifier: ^2.1.0
+        version: 2.1.0(@prisma/client@5.9.0)
       '@faker-js/faker':
         specifier: ^8.4.0
         version: 8.4.0
@@ -381,11 +378,17 @@ packages:
       '@jridgewell/gen-mapping': 0.3.3
       '@jridgewell/trace-mapping': 0.3.22
 
-  /@auth/core@0.24.0:
-    resolution: {integrity: sha512-wwTyapljg4ydyvtQRXSeOaj6nBVSvPkVoXws6i+/vPfINxz4lo9UuLifPLqW7iO72/f4Ttaez0g3XA42VtKQ8A==}
+  /@auth/core@0.31.0:
+    resolution: {integrity: sha512-UKk3psvA1cRbk4/c9CkpWB8mdWrkKvzw0DmEYRsWolUQytQ2cRqx+hYuV6ZCsngw/xbj9hpmkZmAZEyq2g4fMg==}
     peerDependencies:
+      '@simplewebauthn/browser': ^9.0.1
+      '@simplewebauthn/server': ^9.0.2
       nodemailer: ^6.8.0
     peerDependenciesMeta:
+      '@simplewebauthn/browser':
+        optional: true
+      '@simplewebauthn/server':
+        optional: true
       nodemailer:
         optional: true
     dependencies:
@@ -397,46 +400,39 @@ packages:
       preact: 10.11.3
       preact-render-to-string: 5.2.3(preact@10.11.3)
 
-  /@auth/core@0.25.0:
-    resolution: {integrity: sha512-UxENsD+WNlY1NOFsr3Ygc7F1Ypbia8VCd9NU8cbAhSJ0Z8dtyZ0xmssRo1G3ZW50QnW0AaAMuYzY5oumnPMQzA==}
-    peerDependencies:
-      nodemailer: ^6.8.0
-    peerDependenciesMeta:
-      nodemailer:
-        optional: true
-    dependencies:
-      '@panva/hkdf': 1.1.1
-      '@types/cookie': 0.6.0
-      cookie: 0.6.0
-      jose: 5.2.0
-      oauth4webapi: 2.8.1
-      preact: 10.11.3
-      preact-render-to-string: 5.2.3(preact@10.11.3)
-
-  /@auth/prisma-adapter@1.1.0(@prisma/client@5.9.0):
-    resolution: {integrity: sha512-FSHnAmdrrW7b87pKjtnSCOgEthNK9ZAdZJDfncuG3YpXr4whiDfFhqg4UXgmnn/nEXuCIAY6wL3eZIa044vIOQ==}
+  /@auth/prisma-adapter@2.1.0(@prisma/client@5.9.0):
+    resolution: {integrity: sha512-x1gYsi8xCFdxpEM6pxhh7OTV+VHB3PgID2L18y8F1kXu+PbcEWt4VZSQ8zk6dI/4YRStcuwQdHe7neCpczr0mg==}
     peerDependencies:
       '@prisma/client': '>=2.26.0 || >=3 || >=4 || >=5'
     dependencies:
-      '@auth/core': 0.24.0
+      '@auth/core': 0.31.0
       '@prisma/client': 5.9.0(prisma@5.9.0)
     transitivePeerDependencies:
+      - '@simplewebauthn/browser'
+      - '@simplewebauthn/server'
       - nodemailer
     dev: true
 
-  /@auth/sveltekit@0.10.0(@sveltejs/kit@2.0.6)(svelte@4.2.8):
-    resolution: {integrity: sha512-M6FSF7cpHrqKh56VLaU2+GEbCTZCJH2Eb5hkjAaScZGolIqQ9UoVUx6dlOiC0dF9Fewz7Rq3sC8L0RN4n/ifkw==}
+  /@auth/sveltekit@1.1.0(@sveltejs/kit@2.0.6)(svelte@4.2.8):
+    resolution: {integrity: sha512-RdnRBvz09R+dNR7SkjYOedcq2tBozfRidbzq+YogIRHF7+HEeXksJClo4CW6jUC1slWLcTgOpkM9NFPD+4dg6w==}
     peerDependencies:
+      '@simplewebauthn/browser': ^9.0.1
+      '@simplewebauthn/server': ^9.0.3
       '@sveltejs/kit': ^1.0.0 || ^2.0.0
+      nodemailer: ^6.6.5
       svelte: ^3.54.0 || ^4.0.0 || ^5
+    peerDependenciesMeta:
+      '@simplewebauthn/browser':
+        optional: true
+      '@simplewebauthn/server':
+        optional: true
+      nodemailer:
+        optional: true
     dependencies:
-      '@auth/core': 0.24.0
+      '@auth/core': 0.31.0
       '@sveltejs/kit': 2.0.6(@sveltejs/vite-plugin-svelte@3.0.1)(svelte@4.2.8)(vite@5.0.11)
       set-cookie-parser: 2.6.0
       svelte: 4.2.8
-    transitivePeerDependencies:
-      - nodemailer
-    dev: false
 
   /@babel/helper-string-parser@7.23.4:
     resolution: {integrity: sha512-803gmbQdqwdf4olxrX4AJyFBV/RTr3rSmOj0rKwesmzlfhYNDEs+/iOcznzpNWlJlIlTJC2QfPFcHB6DlzdVLQ==}


### PR DESCRIPTION
Upgrades from Auth.js v4 -> v5

## Upgrade notes

### 1. `SvelteKitAuth()` signature is slightly different.

v4: `export const handle = SvelteKitAuth({ ... })`
v5: `export const { handle } = SvelteKitAuth({ ... })`

### 2. Import providers from @auth/sveltekit

v4: `import { GitHub } from `@oauth/core/providers/github`
v5: `import { GitHub } from `@oauth/svetelkit/providers/github`

### 3. Don't have to pass env vars to providers

v4: `providers: { GitHub({ clientId: env.GITHUB_ID, clientSecret: env.GITHUB_SECRET }) }`
v5: `providers: { GitHub }`
